### PR TITLE
Add Pricing and Fix Block Storage attachment flow (issue #8)

### DIFF
--- a/examples/data-sources/eci_pricing/data-source.tf
+++ b/examples/data-sources/eci_pricing/data-source.tf
@@ -1,0 +1,14 @@
+data "eci_pricing" "vm_pricing" {
+  name         = "M-8"
+  pricing_type = "ondemand"
+}
+
+data "eci_pricing" "storage_pricing" {
+  name         = "Block Storage"
+  pricing_type = "ondemand"
+}
+
+data "eci_pricing" "ip_pricing" {
+  name         = "Public IP"
+  pricing_type = "ondemand"
+}

--- a/examples/make-many-vm/main.tf
+++ b/examples/make-many-vm/main.tf
@@ -20,6 +20,25 @@ data "eci_region" "central_01" {
   name = "central-01"
 }
 
+data "eci_instance_type" "test_instance_type" {
+  name = "M-8"
+}
+
+data "eci_pricing" "vm_pricing" {
+  name         = "M-8"
+  pricing_type = "ondemand"
+}
+
+data "eci_pricing" "storage_pricing" {
+  name         = "Block Storage"
+  pricing_type = "ondemand"
+}
+
+data "eci_pricing" "ip_pricing" {
+  name         = "Public IP"
+  pricing_type = "ondemand"
+}
+
 variable "virtual_machine_number" {
   type    = number
   default = 3
@@ -37,6 +56,9 @@ module "virtual_machines" {
   name                   = "many-terraform-test-${count.index}"
   password               = "Secretpa$$w0rd1!"
   instance_type_id       = data.eci_instance_type.test_instance_type.id
+  vm_pricing_id          = data.eci_pricing.vm_pricing.id
+  storage_pricing_id     = data.eci_pricing.storage_pricing.id
+  ip_pricing_id          = data.eci_pricing.ip_pricing.id
   block_storage_image_id = data.eci_block_storage_image.ubuntu2204.id
   block_storage_size     = 100
   subnet_id              = module.network.subnet_id

--- a/examples/make-many-vm/modules/virtual_machine/main.tf
+++ b/examples/make-many-vm/modules/virtual_machine/main.tf
@@ -9,6 +9,7 @@ terraform {
 resource "eci_virtual_machine" "virtual_machine" {
   name             = var.name
   instance_type_id = var.instance_type_id
+  pricing_id       = var.vm_pricing_id
   always_on        = var.always_on
   username         = var.username
   password         = var.password
@@ -31,6 +32,7 @@ resource "eci_block_storage" "block_storage" {
   name                = "${var.name}-block-stroage"
   dr                  = var.dr
   size_gib            = var.block_storage_size
+  pricing_id          = var.storage_pricing_id
   image_id            = var.block_storage_image_id
   tags                = var.tags
 }
@@ -45,6 +47,7 @@ resource "eci_network_interface" "network_interface" {
 
 resource "eci_public_ip" "public_ip" {
   attached_network_interface_id = eci_network_interface.network_interface.id
+  pricing_id                    = var.ip_pricing_id
   dr                            = var.dr
   tags                          = var.tags
 }

--- a/examples/make-many-vm/modules/virtual_machine/variables.tf
+++ b/examples/make-many-vm/modules/virtual_machine/variables.tf
@@ -2,6 +2,18 @@ variable "instance_type_id" {
   type = string
 }
 
+variable "vm_pricing_id" {
+  type = string
+}
+
+variable "storage_pricing_id" {
+  type = string
+}
+
+variable "ip_pricing_id" {
+  type = string
+}
+
 variable "block_storage_image_id" {
   type = string
 }

--- a/examples/make-vm-with-block-storage-snapshot/main.tf
+++ b/examples/make-vm-with-block-storage-snapshot/main.tf
@@ -29,9 +29,25 @@ data "eci_instance_type" "m8" {
   name="M-8"
 }
 
+data "eci_pricing" "vm_pricing" {
+  name="M-8"
+  pricing_type="ondemand"
+}
+
+data "eci_pricing" "storage_pricing" {
+  name="Block Storage"
+  pricing_type="ondemand"
+}
+
+data "eci_pricing" "ip_pricing" {
+  name="Public IP"
+  pricing_type="ondemand"
+}
+
 resource "eci_virtual_machine" "my_virtual_machine2" {
   name="terraform-test-vm-2"
   instance_type_id="${data.eci_instance_type.m8.id}"
+  pricing_id="${data.eci_pricing.vm_pricing.id}"
   always_on=false
   username="elice"
   password="secretpassword1!"
@@ -61,6 +77,7 @@ resource "eci_block_storage" "my_block_storage2" {
   name="terraform-test-2"
   dr=false
   size_gib=40
+  pricing_id="${data.eci_pricing.storage_pricing.id}"
   snapshot_id="a72b896d-7a51-4914-b0f0-c094c3b69ab0"
   tags = {
     "created-by": "terraform"
@@ -82,6 +99,7 @@ resource "eci_public_ip" "my_public_ip2" {
     "${eci_network_interface.my_network_interface_two.id}"
   )
   dr=false
+  pricing_id="${data.eci_pricing.ip_pricing.id}"
   tags = {
     "created-by": "terraform"
   }

--- a/examples/resources/eci_block_storage/resource.tf
+++ b/examples/resources/eci_block_storage/resource.tf
@@ -3,6 +3,7 @@ resource "eci_block_storage" "my_block_storage" {
   name="my-block-strage"
   dr=false
   size_gib=40
+  pricing_id="4f3a9eeb-962f-4f9c-9074-13c422b3d726"
   image_id="4f3a9eeb-962f-4f9c-9074-13c422b3d726"
   tags = {
     "created-by": "terraform"

--- a/examples/resources/eci_public_ip/resource.tf
+++ b/examples/resources/eci_public_ip/resource.tf
@@ -1,6 +1,7 @@
 resource "eci_public_ip" "my_public_ip" {
   attached_network_interface_id="4adf2682-d8f3-451c-8bfc-3383deb424a5"
   dr=false
+  pricing_id="4adf2682-d8f3-451c-8bfc-3383deb424a5"
   tags = {
     "created-by": "terraform"
   }

--- a/examples/resources/eci_virtual_machine/resource.tf
+++ b/examples/resources/eci_virtual_machine/resource.tf
@@ -1,6 +1,7 @@
 resource "eci_virtual_machine" "my_virtual_machine" {
   name="my-vm-1"
   instance_type_id="d0ba1aed-1414-4388-9c2a-9083ae3154d2"
+  pricing_id="d0ba1aed-1414-4388-9c2a-9083ae3154d2"
   always_on=false
   username="elice"
   password="secretpassword1!"

--- a/examples/vm-with-two-network-interfaces/main.tf
+++ b/examples/vm-with-two-network-interfaces/main.tf
@@ -29,9 +29,25 @@ data "eci_instance_type" "test_instance_type" {
   name="M-8"
 }
 
+data "eci_pricing" "vm_pricing" {
+  name="M-8"
+  pricing_type="ondemand"
+}
+
+data "eci_pricing" "storage_pricing" {
+  name="Block Storage"
+  pricing_type="ondemand"
+}
+
+data "eci_pricing" "ip_pricing" {
+  name="Public IP"
+  pricing_type="ondemand"
+}
+
 resource "eci_virtual_machine" "my_virtual_machine" {
   name="terraform-test-vm-1"
   instance_type_id="${data.eci_instance_type.test_instance_type.id}"
+  pricing_id="${data.eci_pricing.vm_pricing.id}"
   always_on=false
   username="elice"
   password="secretpassword1!"
@@ -60,6 +76,7 @@ resource "eci_block_storage" "my_block_storage" {
   name="terraform-test-1"
   dr=false
   size_gib=40
+  pricing_id="${data.eci_pricing.storage_pricing.id}"
   image_id="${data.eci_block_storage_image.ubuntu2204.id}"
   tags = {
     "created-by": "terraform"
@@ -121,6 +138,7 @@ resource "eci_public_ip" "my_public_ip" {
     "${eci_network_interface.my_network_interface_one.id}"
   )
   dr=false
+  pricing_id="${data.eci_pricing.ip_pricing.id}"
   tags = {
     "created-by": "terraform"
   }

--- a/internal/api/block_storage.go
+++ b/internal/api/block_storage.go
@@ -26,6 +26,8 @@ type ResourceBlockStorageGetResponse struct {
 	Deleting           *time.Time        `json:"deleting,omitempty"`
 	Deleted            *time.Time        `json:"deleted,omitempty"`
 	Status             string            `json:"status"`
+	PricingId          uuid.UUID         `json:"pricing_id"`
+	PricingType        string            `json:"pricing_type"`
 }
 
 type ResourceBlockStoragePostResponse struct {
@@ -42,6 +44,7 @@ type ResourceBlockStorageDeleteResponse struct {
 
 func (api *APIClient) PostBlockStorage(
 	name string,
+	pricingId string,
 	imageId *string,
 	snapshotId *string,
 	sizeGiB int,
@@ -54,6 +57,7 @@ func (api *APIClient) PostBlockStorage(
 			"zone_id":         api.ZoneId,
 			"organization_id": api.OrganizationId,
 			"name":            name,
+			"pricing_id":      pricingId,
 			"image_id":        imageId,
 			"snapshot_id":     snapshotId,
 			"size_gib":        sizeGiB,

--- a/internal/api/pricing.go
+++ b/internal/api/pricing.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type PricingGetResponse struct {
+	Id                 uuid.UUID         `json:"id"`
+	Tags               map[string]string `json:"tags"`
+	Created            time.Time         `json:"created"`
+	Modified           *time.Time        `json:"modified,omitempty"`
+	OrganizationId     *uuid.UUID        `json:"organization_id,omitempty"`
+	ZoneId             uuid.UUID         `json:"zone_id"`
+	ResourceKind       string            `json:"resource_kind"`
+	ResourceId         *uuid.UUID        `json:"resource_id,omitempty"`
+	Name               string            `json:"name"`
+	PricingType        string            `json:"pricing_type"`
+	PricePerHour       string            `json:"price_per_hour"`
+	ListedPricePerHour string            `json:"listed_price_per_hour"`
+	Start              *time.Time        `json:"start,omitempty"`
+	End                *time.Time        `json:"end,omitempty"`
+	Activated          bool              `json:"activated"`
+	Quota              *int              `json:"quota,omitempty"`
+}
+
+func (api *APIClient) GetPricings(
+	filterNameIlike *string,
+	filterResourceKind *string,
+	filterPricingType *string,
+	filterActivated *bool,
+	skip int,
+	count int,
+) ([]PricingGetResponse, error) {
+	queryParams := map[string]string{}
+
+	if filterNameIlike != nil {
+		queryParams["filter_name_ilike"] = *filterNameIlike
+	}
+
+	if filterResourceKind != nil {
+		queryParams["filter_resource_kind"] = *filterResourceKind
+	}
+
+	if filterPricingType != nil {
+		queryParams["filter_pricing_type"] = *filterPricingType
+	}
+
+	if filterActivated != nil {
+		if *filterActivated {
+			queryParams["filter_activated"] = "true"
+		} else {
+			queryParams["filter_activated"] = "false"
+		}
+	}
+
+	queryParams["skip"] = fmt.Sprintf("%d", skip)
+	queryParams["count"] = fmt.Sprintf("%d", count)
+
+	resp, err := api.restyClient.R().
+		SetResult(&[]PricingGetResponse{}).
+		SetQueryParams(queryParams).
+		Get(fmt.Sprintf("%s/user/pricing", api.pathPrefix))
+
+	return handleListAPIResponse[PricingGetResponse](resp, err)
+}

--- a/internal/api/public_ip.go
+++ b/internal/api/public_ip.go
@@ -22,6 +22,8 @@ type ResourcePublicIpGetResponse struct {
 	Status                     string            `json:"status"`
 	Ip                         string            `json:"ip"`
 	DrIp                       *string           `json:"dr_ip,omitempty"`
+	PricingId                  uuid.UUID         `json:"pricing_id"`
+	PricingType                string            `json:"pricing_type"`
 }
 
 type ResourcePublicIpPostResponse struct {
@@ -62,13 +64,14 @@ func (api *APIClient) GetPublicIps(
 }
 
 func (api *APIClient) PostPublicIp(
-	dr bool, tags map[string]string,
+	pricingId string, dr bool, tags map[string]string,
 ) (*ResourcePublicIpPostResponse, error) {
 	resp, err := api.restyClient.R().
 		SetResult(&ResourcePublicIpPostResponse{}).
 		SetBody(map[string]interface{}{
 			"zone_id":         api.ZoneId,
 			"organization_id": api.OrganizationId,
+			"pricing_id":      pricingId,
 			"dr":              dr,
 			"tags":            tags,
 		}).

--- a/internal/api/virtual_machine.go
+++ b/internal/api/virtual_machine.go
@@ -25,6 +25,8 @@ type ResourceVirtualMachineGetResponse struct {
 	Name           string            `json:"name"`
 	Username       string            `json:"username"`
 	OnInitScript   string            `json:"on_init_script"`
+	PricingId      uuid.UUID         `json:"pricing_id"`
+	PricingType    string            `json:"pricing_type"`
 }
 
 type ResourceVirtualMachinePostResponse struct {
@@ -50,6 +52,7 @@ func (api *APIClient) GetVirtualMachine(id string) (*ResourceVirtualMachineGetRe
 
 func (api *APIClient) PostVirtualMachine(
 	instanceTypeId string,
+	pricingId string,
 	name string,
 	alwaysOn bool,
 	DR bool,
@@ -64,6 +67,7 @@ func (api *APIClient) PostVirtualMachine(
 			"zone_id":          api.ZoneId,
 			"organization_id":  api.OrganizationId,
 			"instance_type_id": instanceTypeId,
+			"pricing_id":       pricingId,
 			"name":             name,
 			"always_on":        alwaysOn,
 			"dr":               DR,
@@ -80,6 +84,7 @@ func (api *APIClient) PostVirtualMachine(
 func (api *APIClient) PatchVirtualMachine(
 	id string,
 	instanceTypeIdPtr *string,
+	pricingIdPtr *string,
 	namePtr *string,
 	alwaysOnPtr *bool,
 	tagsPtr *map[string]string,
@@ -87,6 +92,7 @@ func (api *APIClient) PatchVirtualMachine(
 	params := map[string]interface{}{}
 	setIfNotNil(params, "name", namePtr)
 	setIfNotNil(params, "instance_type_id", instanceTypeIdPtr)
+	setIfNotNil(params, "pricing_id", pricingIdPtr)
 	setIfNotNil(params, "always_on", alwaysOnPtr)
 	setIfNotNil(params, "tags", tagsPtr)
 

--- a/internal/datasource/pricing.go
+++ b/internal/datasource/pricing.go
@@ -1,0 +1,277 @@
+package datasource
+
+import (
+	"context"
+	"fmt"
+	"terraform-provider-eci/internal/api"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var (
+	_ datasource.DataSource              = &PricingDataSource{}
+	_ datasource.DataSourceWithConfigure = &PricingDataSource{}
+)
+
+func NewPricingDataSource() datasource.DataSource {
+	return &PricingDataSource{}
+}
+
+type PricingDataSource struct {
+	client *api.APIClient
+}
+
+type PricingDataSourceModel struct {
+	Id                 types.String `tfsdk:"id"`
+	Tags               types.Map    `tfsdk:"tags"`
+	Created            types.String `tfsdk:"created"`
+	Modified           types.String `tfsdk:"modified"`
+	OrganizationId     types.String `tfsdk:"organization_id"`
+	ZoneId             types.String `tfsdk:"zone_id"`
+	ResourceKind       types.String `tfsdk:"resource_kind"`
+	ResourceId         types.String `tfsdk:"resource_id"`
+	Name               types.String `tfsdk:"name"`
+	PricingType        types.String `tfsdk:"pricing_type"`
+	PricePerHour       types.String `tfsdk:"price_per_hour"`
+	ListedPricePerHour types.String `tfsdk:"listed_price_per_hour"`
+	Start              types.String `tfsdk:"start"`
+	End                types.String `tfsdk:"end"`
+	Activated          types.Bool   `tfsdk:"activated"`
+	Quota              types.Int64  `tfsdk:"quota"`
+}
+
+func (d *PricingDataSource) Configure(
+	_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse,
+) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*api.APIClient)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"unexpected resource configure type",
+			fmt.Sprintf(
+				`expected *api.APIClient, got: %T. 
+				please report this issue to the provider developers.`,
+				req.ProviderData,
+			),
+		)
+
+		return
+	}
+
+	d.client = client
+}
+
+func (d *PricingDataSource) Metadata(
+	_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse,
+) {
+	resp.TypeName = req.ProviderTypeName + "_pricing"
+}
+
+func (d *PricingDataSource) Schema(
+	_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse,
+) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Pricing",
+
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "unique identifier of the pricing",
+				Computed:    true,
+			},
+			"tags": schema.MapAttribute{
+				ElementType: types.StringType,
+				Description: "user-defined metadata of key-value pairs",
+				Computed:    true,
+			},
+			"created": schema.StringAttribute{
+				Description: "time when the pricing is created",
+				Computed:    true,
+			},
+			"modified": schema.StringAttribute{
+				Description: "last time when the pricing is modified",
+				Computed:    true,
+			},
+			"organization_id": schema.StringAttribute{
+				Description: "id of organization that the pricing belongs to (null for global pricing)",
+				Computed:    true,
+			},
+			"zone_id": schema.StringAttribute{
+				Description: "id of zone that the pricing belongs to",
+				Computed:    true,
+			},
+			"resource_kind": schema.StringAttribute{
+				Description: "kind of resource this pricing applies to (vm_allocation, block_storage, public_ip, etc.)",
+				Optional:    true,
+			},
+			"resource_id": schema.StringAttribute{
+				Description: "id of specific resource instance (null for generic pricing)",
+				Computed:    true,
+			},
+			"name": schema.StringAttribute{
+				Description: "human-readable name of the pricing",
+				Required:    true,
+			},
+			"pricing_type": schema.StringAttribute{
+				Description: "type of pricing (ondemand, reserved)",
+				Required:    true,
+			},
+			"price_per_hour": schema.StringAttribute{
+				Description: "actual price per hour",
+				Computed:    true,
+			},
+			"listed_price_per_hour": schema.StringAttribute{
+				Description: "listed price per hour",
+				Computed:    true,
+			},
+			"start": schema.StringAttribute{
+				Description: "start time of this pricing validity period",
+				Computed:    true,
+			},
+			"end": schema.StringAttribute{
+				Description: "end time of this pricing validity period",
+				Computed:    true,
+			},
+			"activated": schema.BoolAttribute{
+				Description: "whether this pricing is activated",
+				Computed:    true,
+			},
+			"quota": schema.Int64Attribute{
+				Description: "quota limit for this pricing (null for unlimited)",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func PricingGetResponseToPricingModel(
+	ctx context.Context,
+	response *api.PricingGetResponse,
+	data *PricingDataSourceModel,
+) diag.Diagnostics {
+	data.Id = types.StringValue(response.Id.String())
+
+	tags, diags := types.MapValueFrom(ctx, types.StringType, response.Tags)
+	if diags.HasError() {
+		return diags
+	}
+	data.Tags = tags
+
+	data.Created = types.StringValue(response.Created.String())
+
+	if response.Modified != nil {
+		data.Modified = types.StringValue(response.Modified.String())
+	} else {
+		data.Modified = types.StringNull()
+	}
+
+	if response.OrganizationId != nil {
+		data.OrganizationId = types.StringValue(response.OrganizationId.String())
+	} else {
+		data.OrganizationId = types.StringNull()
+	}
+
+	data.ZoneId = types.StringValue(response.ZoneId.String())
+	data.ResourceKind = types.StringValue(response.ResourceKind)
+
+	if response.ResourceId != nil {
+		data.ResourceId = types.StringValue(response.ResourceId.String())
+	} else {
+		data.ResourceId = types.StringNull()
+	}
+
+	data.Name = types.StringValue(response.Name)
+	data.PricingType = types.StringValue(response.PricingType)
+	data.PricePerHour = types.StringValue(response.PricePerHour)
+	data.ListedPricePerHour = types.StringValue(response.ListedPricePerHour)
+
+	if response.Start != nil {
+		data.Start = types.StringValue(response.Start.String())
+	} else {
+		data.Start = types.StringNull()
+	}
+
+	if response.End != nil {
+		data.End = types.StringValue(response.End.String())
+	} else {
+		data.End = types.StringNull()
+	}
+
+	data.Activated = types.BoolValue(response.Activated)
+
+	if response.Quota != nil {
+		data.Quota = types.Int64Value(int64(*response.Quota))
+	} else {
+		data.Quota = types.Int64Null()
+	}
+
+	return diag.Diagnostics{}
+}
+
+func (d *PricingDataSource) Read(
+	ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse,
+) {
+	var config PricingDataSourceModel
+	var state PricingDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	filterActivated := true
+
+	var filterResourceKind *string = nil
+	if !config.ResourceKind.IsNull() {
+		filterResourceKind = config.ResourceKind.ValueStringPointer()
+	}
+
+	pricings, err := d.client.GetPricings(
+		config.Name.ValueStringPointer(),
+		filterResourceKind,
+		config.PricingType.ValueStringPointer(),
+		&filterActivated,
+		0,
+		2,
+	)
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"error while fetching pricings",
+			fmt.Sprintf("error: %v", err.Error()),
+		)
+		return
+	}
+
+	if len(pricings) == 0 {
+		resp.Diagnostics.AddError(
+			"No such pricing",
+			"Zero pricing is returned. Please check your pricing name",
+		)
+		return
+	}
+
+	if len(pricings) > 1 {
+		resp.Diagnostics.AddError(
+			"Multiple pricings returned",
+			"Multiple pricing is returned. Select instance type using id",
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(
+		PricingGetResponseToPricingModel(ctx, &pricings[0], &state)...,
+	)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -167,6 +167,9 @@ func (p *EliceCloudProvider) DataSources(_ context.Context) []func() datasource.
 			return ds.NewInstanceTypeDataSource()
 		},
 		func() datasource.DataSource {
+			return ds.NewPricingDataSource()
+		},
+		func() datasource.DataSource {
 			return ds.NewRegionDataSource()
 		},
 		func() datasource.DataSource {

--- a/internal/resource/resource_block_storage.go
+++ b/internal/resource/resource_block_storage.go
@@ -43,6 +43,8 @@ type ResourceBlockStorageModel struct {
 	SnapshotId         types.String `tfsdk:"snapshot_id"`
 	SizeGib            types.Int64  `tfsdk:"size_gib"`
 	DR                 types.Bool   `tfsdk:"dr"`
+	PricingId          types.String `tfsdk:"pricing_id"`
+	PricingType        types.String `tfsdk:"pricing_type"`
 	LastSyncedSnapshot types.String `tfsdk:"last_synced_snapshot"`
 	Assigned           types.String `tfsdk:"assigned"`
 	Prepared           types.String `tfsdk:"prepared"`
@@ -75,6 +77,8 @@ func resourceBlockStorageGetResponseToBlockStorageModel(
 	data.SnapshotId = StringOrNull(response.SnapshotId)
 	data.SizeGib = types.Int64Value(int64(response.SizeGib))
 	data.DR = types.BoolValue(response.DR)
+	data.PricingId = types.StringValue(response.PricingId.String())
+	data.PricingType = types.StringValue(response.PricingType)
 	data.LastSyncedSnapshot = StringValOrNull(response.LastSyncedSnapshot)
 	data.Assigned = StringOrNull(response.Assigned)
 	data.Prepared = StringOrNull(response.Prepared)
@@ -161,6 +165,14 @@ func (r *ResourceBlockStorage) Schema(
 				Required:      true,
 				PlanModifiers: []planmodifier.Bool{boolplanmodifier.RequiresReplace()},
 			},
+			"pricing_id": schema.StringAttribute{
+				Description: "id of pricing plan for the block storage",
+				Required:    true,
+			},
+			"pricing_type": schema.StringAttribute{
+				Description: "type of pricing plan (computed)",
+				Computed:    true,
+			},
 			"last_synced_snapshot": schema.StringAttribute{
 				Description: "the last time when the block storage is synced with the DR zone",
 				Computed:    true,
@@ -238,6 +250,7 @@ func (r *ResourceBlockStorage) Create(
 
 	response, err := r.client.PostBlockStorage(
 		plan.Name.ValueString(),
+		plan.PricingId.ValueString(),
 		imageIdPtr,
 		plan.SnapshotId.ValueStringPointer(),
 		int(plan.SizeGib.ValueInt64()),
@@ -254,12 +267,58 @@ func (r *ResourceBlockStorage) Create(
 
 	tflog.Trace(ctx, fmt.Sprintf("created a block storage: %s", id))
 
+	getResponse, err := r.client.GetBlockStorage(id)
+	if err != nil {
+		addResourceError(&resp.Diagnostics, "failed to get block storage", id, err)
+		return
+	}
+
+	if getResponse.Status != "prepared" {
+		tflog.Info(ctx, fmt.Sprintf("waiting for block storage (%s) to be prepared", id))
+		_, diags := waitStatus(
+			func() (*string, error) {
+				getResponse, err := r.client.GetBlockStorage(id)
+				if err != nil {
+					return nil, err
+				}
+				return &getResponse.Status, nil
+			},
+			[]string{"prepared"},
+			10,
+		)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			getResponse, _ = r.client.GetBlockStorage(id)
+			if getResponse != nil {
+				resourceBlockStorageGetResponseToBlockStorageModel(ctx, getResponse, &plan)
+				resp.State.Set(ctx, &plan)
+			}
+			return
+		}
+	}
+
+	getResponse, err = r.client.GetBlockStorage(id)
+	if err != nil {
+		addResourceError(&resp.Diagnostics, "failed to get block storage after wait", id, err)
+		return
+	}
+	resourceBlockStorageGetResponseToBlockStorageModel(ctx, getResponse, &plan)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	if !plan.AttachedMachineId.IsNull() {
 		var attachedMachineId = plan.AttachedMachineId.ValueStringPointer()
 		_, err := r.client.PatchBlockStorage(id, nil, &attachedMachineId, nil)
 
 		if err != nil {
-			addResourceError(&resp.Diagnostics, "failed to patch block storage", id, err)
+			addResourceError(
+				&resp.Diagnostics,
+				"failed to patch block storage (attach to VM)",
+				id,
+				err,
+			)
 			return
 		}
 
@@ -269,7 +328,7 @@ func (r *ResourceBlockStorage) Create(
 		)
 	}
 
-	getResponse, err := r.client.GetBlockStorage(id)
+	getResponse, err = r.client.GetBlockStorage(id)
 
 	if err != nil {
 		addResourceError(&resp.Diagnostics, "failed to get block storage", id, err)
@@ -284,23 +343,6 @@ func (r *ResourceBlockStorage) Create(
 		return
 	}
 
-	if getResponse.Status == "prepared" {
-		tflog.Info(ctx, fmt.Sprintf("block storage (%s) is prepared", id))
-		return
-	}
-
-	_, diags := waitStatus(
-		func() (*string, error) {
-			getResponse, err := r.client.GetBlockStorage(id)
-			if err != nil {
-				return nil, err
-			}
-			return &getResponse.Status, nil
-		},
-		[]string{"prepared"},
-		10,
-	)
-	resp.Diagnostics.Append(diags...)
 }
 
 func (r *ResourceBlockStorage) Read(
@@ -318,7 +360,7 @@ func (r *ResourceBlockStorage) Read(
 	response, err := r.client.GetBlockStorage(id)
 
 	if err != nil {
-		addResourceError(&resp.Diagnostics, "failed to create block stroage", id, err)
+		addResourceError(&resp.Diagnostics, "failed to get block storage", id, err)
 		return
 	}
 
@@ -348,7 +390,7 @@ func (r *ResourceBlockStorage) Update(
 
 			_, err := r.client.PatchBlockStorage(id, nil, &nilAttachedMachineId, nil)
 			if err != nil {
-				addResourceError(&resp.Diagnostics, "failed to detach block stroage", id, err)
+				addResourceError(&resp.Diagnostics, "failed to detach block storage", id, err)
 				return
 			}
 
@@ -382,7 +424,7 @@ func (r *ResourceBlockStorage) Update(
 	_, err := r.client.PatchBlockStorage(id, namePtr, attachedMachineIdPtr, tagsPtr)
 
 	if err != nil {
-		addResourceError(&resp.Diagnostics, "failed to patch block stroage", id, err)
+		addResourceError(&resp.Diagnostics, "failed to patch block storage", id, err)
 		return
 	}
 
@@ -427,7 +469,7 @@ func (r *ResourceBlockStorage) Delete(
 
 		if virtualMachine.Status != "idle" {
 			resp.Diagnostics.AddError(
-				"Invalid virtual machien status",
+				"Invalid virtual machine status",
 				"block storage is attached to a non-idle virtual machine. For safety, the practitioner has to kill the virtual machine allocation",
 			)
 			return

--- a/internal/resource/resource_public_ip.go
+++ b/internal/resource/resource_public_ip.go
@@ -27,6 +27,8 @@ type ResourcePublicIpModel struct {
 	OrganizationId             types.String `tfsdk:"organization_id"`
 	DR                         types.Bool   `tfsdk:"dr"`
 	AttachedNetworkInterfaceId types.String `tfsdk:"attached_network_interface_id"`
+	PricingId                  types.String `tfsdk:"pricing_id"`
+	PricingType                types.String `tfsdk:"pricing_type"`
 	PoolId                     types.String `tfsdk:"pool_id"`
 	DrPoolId                   types.String `tfsdk:"dr_pool_id"`
 	Ip                         types.String `tfsdk:"ip"`
@@ -60,6 +62,8 @@ func resourcePublicIpGetResponseToPublicIpModel(
 	data.OrganizationId = types.StringValue(response.OrganizationId.String())
 	data.DR = types.BoolValue(response.DR)
 	data.AttachedNetworkInterfaceId = StringOrNull(response.AttachedNetworkInterfaceId)
+	data.PricingId = types.StringValue(response.PricingId.String())
+	data.PricingType = types.StringValue(response.PricingType)
 	data.PoolId = types.StringValue(response.PoolId.String())
 	data.DrPoolId = StringOrNull(response.DrPoolId)
 	data.Deleted = StringOrNull(response.Deleted)
@@ -133,6 +137,14 @@ func (r *ResourcePublicIp) Schema(
 				Required:      true,
 				PlanModifiers: []planmodifier.Bool{boolplanmodifier.RequiresReplace()},
 			},
+			"pricing_id": schema.StringAttribute{
+				Description: "id of pricing plan for the public IP",
+				Required:    true,
+			},
+			"pricing_type": schema.StringAttribute{
+				Description: "type of pricing plan (computed)",
+				Computed:    true,
+			},
 			"pool_id":    schema.StringAttribute{Computed: true},
 			"dr_pool_id": schema.StringAttribute{Computed: true},
 			"deleted": schema.StringAttribute{
@@ -194,7 +206,7 @@ func (r *ResourcePublicIp) Create(
 		return
 	}
 
-	response, err := r.client.PostPublicIp(plan.DR.ValueBool(), tags)
+	response, err := r.client.PostPublicIp(plan.PricingId.ValueString(), plan.DR.ValueBool(), tags)
 
 	if err != nil {
 		addResourceError(

--- a/internal/resource/resource_virtual_machine.go
+++ b/internal/resource/resource_virtual_machine.go
@@ -34,6 +34,8 @@ type ResourceVirtualMachineModel struct {
 	ZoneId         types.String `tfsdk:"zone_id"`
 	OrganizationId types.String `tfsdk:"organization_id"`
 	InstanceTypeId types.String `tfsdk:"instance_type_id"`
+	PricingId      types.String `tfsdk:"pricing_id"`
+	PricingType    types.String `tfsdk:"pricing_type"`
 
 	AlwaysOn     types.Bool   `tfsdk:"always_on"`
 	Name         types.String `tfsdk:"name"`
@@ -66,6 +68,8 @@ func resourceVirtualMachineGetResponseToVirtualMachineModel(
 	data.ZoneId = types.StringValue(response.ZoneId.String())
 	data.OrganizationId = types.StringValue(response.OrganizationId.String())
 	data.InstanceTypeId = types.StringValue(response.InstanceTypeId.String())
+	data.PricingId = types.StringValue(response.PricingId.String())
+	data.PricingType = types.StringValue(response.PricingType)
 	data.AlwaysOn = types.BoolValue(response.AlwaysOn)
 	data.DR = types.BoolValue(response.DR)
 	data.Allocated = StringOrNull(response.Allocated)
@@ -128,6 +132,14 @@ func (r *ResourceVirtualMachine) Schema(
 				Required:    true,
 				Computed:    false,
 				Optional:    false,
+			},
+			"pricing_id": schema.StringAttribute{
+				Description: "id of pricing plan for the virtual machine",
+				Required:    true,
+			},
+			"pricing_type": schema.StringAttribute{
+				Description: "type of pricing plan (computed)",
+				Computed:    true,
 			},
 			"always_on": schema.BoolAttribute{
 				Description: "whether to automatically restart the virtual machine when migrated to DR",
@@ -209,6 +221,7 @@ func (r *ResourceVirtualMachine) Create(
 
 	response, err := r.client.PostVirtualMachine(
 		plan.InstanceTypeId.ValueString(),
+		plan.PricingId.ValueString(),
 		plan.Name.ValueString(),
 		plan.AlwaysOn.ValueBool(),
 		plan.DR.ValueBool(),
@@ -295,6 +308,11 @@ func (r *ResourceVirtualMachine) Update(
 		instanceTypeIdPtr = plan.InstanceTypeId.ValueStringPointer()
 	}
 
+	var pricingIdPtr *string = nil
+	if !plan.PricingId.Equal(state.PricingId) {
+		pricingIdPtr = plan.PricingId.ValueStringPointer()
+	}
+
 	var tagsPtr *map[string]string = nil
 	if !plan.Tags.Equal(state.Tags) {
 		tags := map[string]string{}
@@ -308,7 +326,7 @@ func (r *ResourceVirtualMachine) Update(
 
 	id := state.Id.ValueString()
 	_, err := r.client.PatchVirtualMachine(
-		id, instanceTypeIdPtr, namePtr, alwaysOnPtr, tagsPtr,
+		id, instanceTypeIdPtr, pricingIdPtr, namePtr, alwaysOnPtr, tagsPtr,
 	)
 
 	if err != nil {
@@ -404,7 +422,7 @@ func (r *ResourceVirtualMachine) Delete(
 
 	if state.AlwaysOn.ValueBool() {
 		var falsePtr = false
-		_, err = r.client.PatchVirtualMachine(id, nil, nil, &falsePtr, nil)
+		_, err = r.client.PatchVirtualMachine(id, nil, nil, nil, &falsePtr, nil)
 		if err != nil {
 			addResourceError(
 				&resp.Diagnostics,


### PR DESCRIPTION
Closes #8

## Key Changes
### 1. Pricing API Integration
- Resources: Added pricing_id (Required) and pricing_type (Computed) to eci_virtual_machine, eci_block_storage, and eci_public_ip.
- Data Source: Introduced the pricing data source. Users can now query the correct pricing_id using name, pricing_type.
- Updated Examples
### 2. Block Storage Attachment Flow
- Updated the `ResourceBlockStorage` creation flow to comply with the updated `eci-api`specification, which now requires block storage to be prepared before attaching a machine.
- Create `Block Storage` ➔ Wait for `prepared` status ➔ Save intermediate state ➔ Attach to`Virtual Machine` ➔ Save final state 
