### PR TITLE
fix: avoid plan overwrite in block storage create

### DIFF
--- a/internal/resource/resource_block_storage.go
+++ b/internal/resource/resource_block_storage.go
@@ -302,8 +302,10 @@ func (r *ResourceBlockStorage) Create(
 		addResourceError(&resp.Diagnostics, "failed to get block storage after wait", id, err)
 		return
 	}
-	resourceBlockStorageGetResponseToBlockStorageModel(ctx, getResponse, &plan)
-	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+
+	state := plan
+	resourceBlockStorageGetResponseToBlockStorageModel(ctx, getResponse, &state)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/resource/resource_block_storage.go
+++ b/internal/resource/resource_block_storage.go
@@ -290,8 +290,9 @@ func (r *ResourceBlockStorage) Create(
 		if resp.Diagnostics.HasError() {
 			getResponse, _ = r.client.GetBlockStorage(id)
 			if getResponse != nil {
-				resourceBlockStorageGetResponseToBlockStorageModel(ctx, getResponse, &plan)
-				resp.State.Set(ctx, &plan)
+				state := plan
+				resourceBlockStorageGetResponseToBlockStorageModel(ctx, getResponse, &state)
+				resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 			}
 			return
 		}
@@ -337,9 +338,9 @@ func (r *ResourceBlockStorage) Create(
 		return
 	}
 
-	resourceBlockStorageGetResponseToBlockStorageModel(ctx, getResponse, &plan)
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	state = plan
+	resourceBlockStorageGetResponseToBlockStorageModel(ctx, getResponse, &state)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 
 	if resp.Diagnostics.HasError() {
 		return


### PR DESCRIPTION
Use a separate state in block storage create to avoid overwriting planned values and prevent apply inconsistency.